### PR TITLE
Add tutorial of getting number of on-queue agents in a queue

### DIFF
--- a/number-of-agent-in-queue/config.yaml
+++ b/number-of-agent-in-queue/config.yaml
@@ -1,0 +1,13 @@
+---
+ruby:
+python:
+    displayName: Python
+    steps:
+        - file: "python/script.py"
+          highlight: "0-76"
+        - file: "python/script.py"
+          highlight: "8-32"
+        - file: "python/script.py"
+          highlight: "32-38"
+        - file: "python/script.py"
+          highlight: "38-76"

--- a/number-of-agent-in-queue/config.yaml
+++ b/number-of-agent-in-queue/config.yaml
@@ -1,5 +1,4 @@
 ---
-ruby:
 python:
     displayName: Python
     steps:

--- a/number-of-agent-in-queue/index.html.haml
+++ b/number-of-agent-in-queue/index.html.haml
@@ -1,0 +1,35 @@
+.tutorial{:data =>{:title=>'Get Number of On-Queue Agents using PureCloud SDK'}}
+    .step{:data=>{:title=>'Introduction'}}
+        :markdown
+			This tutorial walks throught the steps of implementing a function to get the number of On-Queue Agents on a specific queue.
+			
+			There are 5 tpes of Routing Status: IDLE, INTERACTING, COMMUNINCATING, OFF_QUEUE, and NOT_RESPONDING. To determine if an agent is On-Queue, he/she should have a routing status of either IDLE or INTERACTING.
+			
+			Go here for more information about [Presences and Routing Status](https://developer.mypurecloud.com/api/rest/v2/presence/understanding_presence.html):
+            
+			For this tutorial, we are going to use the Python PureCloud SDK.
+
+    .step{:data=>{:title=>'Obtain an Access Token'}}
+        :markdown
+            Start by making a POST call to https://login.mypurecloud.com/oauth/token with the following settings:
+            * Authentication- Basic
+            * User - Client ID
+            * Password-  Client secret
+
+            To use basic authentication, set the authentication header to ```Basic <base64EncodedUserPass>```, where base64EncodedUserPass is a base64-encoded string containing the username and password separated by a colon:
+              base64.b64encode(bytes(client_id + ':' + client_secret, 'ISO-8859-1')).decode('ascii')
+			
+            Note: Base64 encoding differs between Python 2 and Python 3. This implementation is for Python 3.
+
+    .step{:data=>{:title=>'Create instance of Routing API'}}
+        :markdown
+            Configure the token to be used by the PureCloud SDK. This token will be sent along every API call automatically.
+			
+			Create an instance of the Routing API which will be used to make the API calls.
+	.step{:data=>{:title=>'Create the function'}}
+        :markdown
+            First, search for the queue using its name. It should return exactly one result, otherwise it should return an exception.
+			
+			The next API call should get the users of the queue with the desired routing status. ("IDLE", "INTERACTING").
+			
+			The number of users will simple be returned from the function.

--- a/number-of-agent-in-queue/python/script.py
+++ b/number-of-agent-in-queue/python/script.py
@@ -1,0 +1,74 @@
+import base64, json, requests
+import PureCloudPlatformClientV2
+from PureCloudPlatformClientV2.rest import ApiException
+
+print('-------------------------------------------------------------')
+print('- Python3 Get Number of On-Queue Agents using PureCloud SDK -')
+print('-------------------------------------------------------------')
+
+# Oauth Client Credentials
+client_id = 'd3b70533-d806-4ff8-9f35-sample'
+client_secret = 'o3q5E87GyLlB-D_hQ09Odaur2F_sample'
+authorization = base64.b64encode(bytes(client_id + ':' + client_secret, 'ISO-8859-1')).decode('ascii')
+
+# Prepare for POST /oauth/token request
+request_headers = {
+	'Authorization': 'Basic ' + authorization,
+	'Content-Type': 'application/x-www-form-urlencoded'
+}
+request_body = {
+	'grant_type': 'client_credentials'
+}	
+
+# Get token
+response = requests.post('https://login.mypurecloud.com/oauth/token', data=request_body, headers=request_headers)
+
+# Check response
+if response.status_code == 200:
+	print('Got token')
+else:
+	print('Failure: ' + str(response.status_code) + ' - ' + response.reason)
+	sys.exit(response.status_code)
+	
+# Configure the token for use by the SDK
+PureCloudPlatformClientV2.configuration.access_token = response.json()['access_token']
+
+# Create an instance of the Routing API
+routing_api = PureCloudPlatformClientV2.RoutingApi()
+
+def get_on_queue_agents(queue_name):
+	""" Get number of agents active on a queue given the name of the queue.
+	Args:
+		queueName (str): Name of the Queue.
+	Returns:
+		int: Number of agents 'on-queue'.
+	"""
+	queue_id = 0
+	on_queue_agents = 0
+	
+	# Search for the routing id of the queue
+	try:
+		api_response = routing_api.get_routing_queues(name=queue_name)
+		
+		# Check for the number of entities returned
+		if(len(api_response.entities) < 1):
+			print("Queue not found.")
+			return -1
+		elif(len(api_response.entities) > 1):
+			print("Found more than one queue with the name. Getting the first one.")
+		else:
+			# Get the id of the queue
+			queue_id = api_response.entities[0].id
+		
+	except ApiException as e:
+		print("Error on RoutingAPI -> " + e)
+		
+	# Count the 'on-queue' agents on the queue.
+	try:
+		api_response = routing_api.get_routing_queue_users(queue_id, 
+			routing_status=["IDLE","INTERACTING"])
+		on_queue_agents = api_response.total
+	except ApiException as e:
+		print("Error on RoutingAPI -> " + e)
+	
+	return on_queue_agents


### PR DESCRIPTION
Using the name of the queue, get how many agents are on-queue regardless if currently engaged in an interaction or not. 

Some customers were requesting if it's possible to pull up the information in Architect which is currently not possible. The tutorial is a sample of this funcitonality and can be modified as a webservice to be called in Architect.